### PR TITLE
adding markdown support and flyout menu

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,0 +1,9 @@
+<head>
+  <meta name="readthedocs-addons-api-version" content="1" />
+  {{ super() }}
+</head>
+<body>
+  {{ body }}
+  <readthedocs-flyout position="bottom-right"></readthedocs-flyout>
+  <script src="https://readthedocs-addons.readthedocs.io/readthedocs-addons.js"></script>
+</body>

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,12 +2,12 @@
 
 # -- Project information
 
-project = 'Lumache'
-copyright = '2021, Graziella'
-author = 'Graziella'
+project = 'Hosting Documentation'
+copyright = '2025, CSE @ PSTU'
+author = 'Mir Suhail Asarat'
 
 release = '0.1'
-version = '0.1.0'
+version = '0.1.1'
 
 # -- General configuration
 
@@ -17,7 +17,11 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
+    'sphinx_rtd_theme',
+    'myst_parser',
 ]
+
+source_suffix = ['.rst', '.md']
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
@@ -30,6 +34,12 @@ templates_path = ['_templates']
 # -- Options for HTML output
 
 html_theme = 'sphinx_rtd_theme'
+
+html_theme_options = {
+  'flyout_display': 'attached',  # or 'hidden' to disable default injected flyout
+  'version_selector': True,
+  'language_selector': True,
+}
 
 # -- Options for EPUB output
 epub_show_urls = 'footnote'


### PR DESCRIPTION
in `conf.py` file for markdown support using MyST,

```
extensions = ['myst_parser']
source_suffix = ['.rst', '.md']
```


in `conf.py` file for flyout menu using `sphinx_rtd_theme`,

```
extensions = ['sphinx_rtd_theme']

html_theme = 'sphinx_rtd_theme'

html_theme_options = {
  'flyout_display': 'attached',  # or 'hidden' to disable default injected flyout
  'version_selector': True,
  'language_selector': True,
}
```

and for addon flyout snippet and API meta in template file in `docs/source/_templates/layout.html`,

```
<head>
  <meta name="readthedocs-addons-api-version" content="1" />
  {{ super() }}
</head>
<body>
  {{ body }}
  <readthedocs-flyout position="bottom-right"></readthedocs-flyout>
  <script src="https://readthedocs-addons.readthedocs.io/readthedocs-addons.js"></script>
</body>
```
